### PR TITLE
Adding azure-event-hubs to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ languages:
 - java
 products:
 - azure
+- azure-event-hubs
 extensions:
   services: Eventhubs
   platforms: java


### PR DESCRIPTION
Adding azure-event-hubs to products so that the sample shows up when I search with Azure & Event Hubs in https://docs.microsoft.com/en-us/samples/browse/?expanded=azure&products=azure-event-hubs.